### PR TITLE
Fixing a case where alias.to is not an array

### DIFF
--- a/update/update-aliases.js
+++ b/update/update-aliases.js
@@ -59,7 +59,7 @@ function updateAliases (domain, creds, aliases, callback) {
 
     toAdd.forEach(function (alias) {
       var to = Array.isArray(alias.to) ? alias.to : [ alias.to ]
-      console.log(`Adding ${alias.from} -> ${alias.to.join(', ')}...`)
+      console.log(`Adding ${alias.from} -> ${to.join(', ')}...`)
       addRoute(domain, creds, alias.from, alias.expression, alias.actions, done)
     })
 


### PR DESCRIPTION
```
Adding security -> <redacted>..
/data/src/nodejs-email/update/update-aliases.js:62
      console.log(`Adding ${alias.from} -> ${alias.to.join(', ')}...`)
                                                      ^
TypeError: alias.to.join is not a function
    at /data/src/nodejs-email/update/update-aliases.js:62:55
    at Array.forEach (native)
    at adjustRoutes (/data/src/nodejs-email/update/update-aliases.js:60:11)
    at /data/src/nodejs-email/update/update-aliases.js:75:5
    at BufferList._callback (/data/src/nodejs-email/update/node_modules/jsonist/jsonist.js:25:5)
    at BufferList.end (/data/src/nodejs-email/update/node_modules/bl/bl.js:78:10)
    at DestroyableTransform.onend (/data/src/nodejs-email/update/node_modules/hyperquest/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:523:10)
    at DestroyableTransform.g (events.js:260:16)
    at emitNone (events.js:72:20)
    at DestroyableTransform.emit (events.js:166:7)
```

Currently the code always `console.log` on `alias.to.join(...)` which may not be an array. There's a preceding line where `to` is initialized to always be an array, but it's not used.

This fixes that bug.