### PR TITLE
added ci-alert@ alias for Jenkins alerts

### DIFF
--- a/iojs.org/aliases.json
+++ b/iojs.org/aliases.json
@@ -30,5 +30,13 @@
     "reis@janeasystems.com"
   ] },
   { "from": "rvagg", "to": "rod@vagg.org" },
-  { "from": "jbergstroem", "to": "bugs@bergstroem.nu" }
+  { "from": "jbergstroem", "to": "bugs@bergstroem.nu" },
+  { "from": "ci-alert", "to": [
+    "rvagg@iojs.org",
+    "jbergstroem@iojs.org",
+    "reis@janeasystems.com",
+    "alexis@janeasystems.com",
+    "michael_dawson@ca.ibm.com",
+    "hans@starefossen.com"
+  ] }
 ]


### PR DESCRIPTION
This pull request adds `ci-alert@` alias which will be used to send out Jenkins slave downtime alerts. 