### PR TITLE
aliases: add report alias

### DIFF
--- a/iojs.org/aliases.json
+++ b/iojs.org/aliases.json
@@ -1,4 +1,7 @@
 [
+  { "from": "report", "to": [
+    "tsc@iojs.org"
+  ]},
   { "from": "security", "to": [
     "security@nodejs.org"
   ] },


### PR DESCRIPTION
For now, map the `report@io.js` alias to `tsc@io.js`. We can scope
this down to individuals if/when it becomes necessary. For now,
the TSC handles moderation and CoC violation issues so this seems
appropriate.