### PR TITLE
remove unused email address for defunct WG

### DIFF
--- a/iojs.org/aliases.json
+++ b/iojs.org/aliases.json
@@ -69,16 +69,5 @@
     "hans@starefossen.com",
     "johphi@gmail.com",
     "gib@uk.ibm.com"
-  ] },
-  { "from": "inclusivity", "to": [
-    "beau@beaugunderson.com",
-    "nathan@nathan7.eu",
-    "bryan@nebri.us",
-    "jona@jona.io",
-    "thechargingvolcano@gmail.com",
-    "rtrott@gmail.com",
-    "scott.gonzalez@gmail.com",
-    "julianduquej@gmail.com",
-    "tracyhinds@gmail.com"
   ] }
 ]


### PR DESCRIPTION
The email for the inclusivity group has not
been used in a long, long time. (I know because I'm on it.) Let's remove
it so there's no confusion about whether or not it should be used. The WG
is no longer. (Much of the work is now being assumed by the Community Committee.)