### PR TITLE
Add download-validation-alert

### DIFF
--- a/iojs.org/aliases.json
+++ b/iojs.org/aliases.json
@@ -77,5 +77,8 @@
     "hi@jennwrit.es",
     "bryan@nebri.us",
     "michael_dawson@ca.ibm.com"
+  ] },
+    { "from": "download-validation-alert", "to": [
+      "michael_dawson@ca.ibm.com"
   ] }
 ]

--- a/iojs.org/aliases.json
+++ b/iojs.org/aliases.json
@@ -78,7 +78,7 @@
     "bryan@nebri.us",
     "michael_dawson@ca.ibm.com"
   ] },
-    { "from": "download-validation-alert", "to": [
+    { "from": "release-validation-alert", "to": [
       "michael_dawson@ca.ibm.com"
   ] }
 ]


### PR DESCRIPTION
Add alias for notification of when the download
validation job fails
https://ci.nodejs.org/view/Node.js%20Daily/job/validate-downloads/

Started with just my email.  Have  asked release/build team who else should be added and will update PR once I get responses.