### PR TITLE
Remove Jenn Turner

### DIFF
--- a/iojs.org/aliases.json
+++ b/iojs.org/aliases.json
@@ -97,7 +97,6 @@
     "loveless@gmail.com",
     "joesepi@gmail.com",
     "tracyhinds@gmail.com",
-    "hi@jennwrit.es",
     "michael_dawson@ca.ibm.com"
   ] },
     { "from": "release-validation-alert", "to": [


### PR DESCRIPTION
Removes Jenn Turner from CommComm alias (ref: https://github.com/nodejs/community-committee/pull/132)