### PR TITLE
remove bnoordhuis from lists

### DIFF
--- a/iojs.org/aliases.json
+++ b/iojs.org/aliases.json
@@ -1,7 +1,6 @@
 [
   { "from": "tsc", "to": [
     "anna@addaleax.net",
-    "info@bnoordhuis.nl",
     "chalkerx@gmail.com",
     "cjihrig@gmail.com",
     "evanlucas@me.com",
@@ -25,7 +24,6 @@
   ] },
   { "from": "ctc", "to": [
     "anna@addaleax.net",
-    "info@bnoordhuis.nl",
     "chalkerx@gmail.com",
     "cjihrig@gmail.com",
     "evanlucas@me.com",


### PR DESCRIPTION
Ben has resigned from TSC, so removing from the TSC and CTC lists. I
made the judgment call that he should be removed from the security list
as well as everyone else on that list is TSC and they can always loop
him in if need be. Not feeling too strongly about that though if there's
strong opposition.