### PR TITLE
update build aliases

### DIFF
--- a/iojs.org/aliases.json
+++ b/iojs.org/aliases.json
@@ -64,15 +64,22 @@
     "rtrott@gmail.com"
   ] },
   { "from": "admin", "to": [
+    "jbergstroem@iojs.org",
+    "michael_dawson@ca.ibm.com",
+    "reis@janeasystems.com",
     "rod@vagg.org"
   ] },
   { "from": "accounts", "to": [
+    "jbergstroem@iojs.org",
+    "michael_dawson@ca.ibm.com",
+    "reis@janeasystems.com",
     "rod@vagg.org"
   ] },
   { "from": "build", "to": [
-    "rod@vagg.org",
     "jbergstroem@iojs.org",
-    "michael_dawson@ca.ibm.com"
+    "michael_dawson@ca.ibm.com",
+    "reis@janeasystems.com",
+    "rod@vagg.org"
   ] },
   { "from": "ci", "to": [
     "reis@janeasystems.com"


### PR DESCRIPTION
/cc @nodejs/build 

I've been using DigiCert to get this Authenticode cert renewal done and noticed it's one of the accounts we're using accounts@iojs.org for, so I'm formalising that here, also properly expanding to the build/infra group on each of these 3 addresses.