### PR TITLE
Add email aliases for acting as CNA

### DIFF
--- a/iojs.org/aliases.json
+++ b/iojs.org/aliases.json
@@ -119,12 +119,12 @@
     { "from": "cve-request", "to": [
       "michael_dawson@ca.ibm.com",
       "info@bnoordhuis.nl",
-      "viewtech@gmail.com"
+      "vieuxtech@gmail.com",
   ] },
     { "from": "cve-mitre-contact", "to": [
       "michael_dawson@ca.ibm.com",
       "info@bnoordhuis.nl",
-      "viewtech@gmail.com"
+      "vieuxtech@gmail.com",
   ] },
     { "from": "cna-discussion-list", "to": [
       "michael_dawson@ca.ibm.com"

--- a/iojs.org/aliases.json
+++ b/iojs.org/aliases.json
@@ -115,5 +115,18 @@
       "gibfahn@gmail.com",
       "hello@bnb.im",
       "rtrott@gmail.com"
+  ] },
+    { "from": "cve-request", "to": [
+      "michael_dawson@ca.ibm.com",
+      "info@bnoordhuis.nl",
+      "viewtech@gmail.com"
+  ] },
+    { "from": "cve-mitre-contact", "to": [
+      "michael_dawson@ca.ibm.com",
+      "info@bnoordhuis.nl",
+      "viewtech@gmail.com"
+  ] },
+    { "from": "cna-discussion-list", "to": [
+      "michael_dawson@ca.ibm.com"
   ] }
 ]


### PR DESCRIPTION
Add email aliases for acting as a CNA asas per:
https://github.com/nodejs/security-wg/issues/33

cve-request  - email address that people should be directed to
               in order to ask questions about CVE-related issues

cve-mitre-contact - private contact points for mitre to reach out
                    directly to in case there are issues that required
                    immediate attention

cna-discussion-list - email address added ot the CNA email discussion list.
                      Used for announcements, sharing documents or discussion
                      relevant to CNA community. Rarely has more than 10
                      messages a week