### PR TITLE
Remove JP from CommComm alias.

### DIFF
--- a/iojs.org/aliases.json
+++ b/iojs.org/aliases.json
@@ -101,7 +101,6 @@
     "joesepi@gmail.com",
     "tracyhinds@gmail.com",
     "michael_dawson@ca.ibm.com",
-    "jpwesselink@gmail.com",
     "msmichellegar@gmail.com"
   ] },
     { "from": "release-validation-alert", "to": [


### PR DESCRIPTION
Removes "jpwesselink@gmail.com" from CommComm alias.