### PR TITLE
add third party email reporting alias to hackerone

### DIFF
--- a/iojs.org/aliases.json
+++ b/iojs.org/aliases.json
@@ -129,5 +129,8 @@
   ] },
     { "from": "cna-discussion-list", "to": [
       "michael_dawson@ca.ibm.com"
+  ] },
+    { "from": "security-ecosystem", "to": [
+      "nodejs-ecosystem-f6dff0c98b32758c@forwarding.hackerone.com"
   ] }
 ]


### PR DESCRIPTION
As decided in https://github.com/nodejs/security-wg/blob/master/meetings/2017-11-02.md#actions we would like to set up an email alias for reporting vulnerabilities in third party modules to our HackerOne organization.