### PR TITLE
Add github-bot alias

### DIFF
--- a/iojs.org/aliases.json
+++ b/iojs.org/aliases.json
@@ -200,5 +200,17 @@
       "rod@vagg.org",
       "zeke@sikelianos.com"
     ]
+  },
+  {
+    "from": "github-bot",
+    "to": [
+      "bugs@bergstroem.nu",
+      "fishrock123@rocketmail.com",
+      "johphi@gmail.com",
+      "joyeec9h3@gmail.com",
+      "me@jonathanmoss.me"
+      "mscdex@mscdex.net",
+      "william.kapke@gmail.com"
+    ]
   }
 ]


### PR DESCRIPTION
This adds a new alias with all the current members of @nodejs/github-bot.

Refs https://github.com/nodejs/build/issues/1354