### PR TITLE
create node-slack-bot alias

### DIFF
--- a/iojs.org/aliases.json
+++ b/iojs.org/aliases.json
@@ -82,6 +82,7 @@
   {
     "from": "build",
     "to": [
+      "george.adams@uk.ibm.com",
       "jbergstroem@iojs.org",
       "michael_dawson@ca.ibm.com",
       "reis@janeasystems.com",

--- a/iojs.org/aliases.json
+++ b/iojs.org/aliases.json
@@ -82,7 +82,6 @@
   {
     "from": "build",
     "to": [
-      "george.adams@uk.ibm.com",
       "jbergstroem@iojs.org",
       "michael_dawson@ca.ibm.com",
       "reis@janeasystems.com",
@@ -255,5 +254,12 @@
       "richard.littauer@gmail.com",
       "zeke@sikelianos.com"
       ]
+  },
+    {
+    "from": "node-slack-bot",
+    "to": [
+      "george.adams@uk.ibm.com",
+      "refack@gmail.com"
+    ]
   }
 ]


### PR DESCRIPTION
used to authenticate the `node-slack-bot` user on IRC