### PR TITLE
remove timothygu and mrhinkle from email lists

### DIFF
--- a/iojs.org/aliases.json
+++ b/iojs.org/aliases.json
@@ -19,8 +19,7 @@
       "r@va.gg",
       "rtrott@gmail.com",
       "targos@protonmail.com",
-      "thechargingvolcano@gmail.com",
-      "timothygu99@gmail.com"
+      "thechargingvolcano@gmail.com"
     ]
   },
   {
@@ -228,7 +227,6 @@
     "from": "crypto-export",
     "to": [
       "myles.borins@gmail.com",
-      "mhinkle@linuxfoundation.org",
       "anna@addaleax.net",
       "chalkerx@gmail.com",
       "cjihrig@gmail.com",
@@ -245,8 +243,7 @@
       "r@va.gg",
       "rtrott@gmail.com",
       "targos@protonmail.com",
-      "thechargingvolcano@gmail.com",
-      "timothygu99@gmail.com"
+      "thechargingvolcano@gmail.com"
     ]
   },
   {


### PR DESCRIPTION
timothygu is TSC emeritus now.

mrhinkle is no longer with linux foundation.