### PR TITLE
add Richard Lau to release-validation-alert alias

### DIFF
--- a/iojs.org/aliases.json
+++ b/iojs.org/aliases.json
@@ -148,7 +148,8 @@
   {
     "from": "release-validation-alert",
     "to": [
-      "midawson@redhat.com"
+      "midawson@redhat.com",
+      "rlau@redhat.com"
     ]
   },
   {


### PR DESCRIPTION
This alias is used for alerts when the `validate-downloads`[1] CI job fails.

[1] https://ci.nodejs.org/view/Node.js%20Daily/job/validate-downloads/