### PR TITLE
chore: remove ctc email

### DIFF
--- a/iojs.org/aliases.json
+++ b/iojs.org/aliases.json
@@ -26,20 +26,6 @@
     ]
   },
   {
-    "from": "ctc",
-    "to": [
-      "chalkerx@gmail.com",
-      "cjihrig@gmail.com",
-      "franziska.hinkelmann@gmail.com",
-      "joyeec9h3@gmail.com",
-      "matteo.collina@gmail.com",
-      "midawson@redhat.com",
-      "myles.borins@gmail.com",
-      "rtrott@gmail.com",
-      "targos@protonmail.com"
-    ]
-  },
-  {
     "from": "security",
     "to": [
       "nodejs-79566c66a30b0312@forwarding.hackerone.com"


### PR DESCRIPTION
The ctc email address was internal only and has not received any email
for years. The CTC has not existed for years. Let's delete the email
address.