### PR TITLE
chore: remove unused email addresses

### DIFF
--- a/iojs.org/aliases.json
+++ b/iojs.org/aliases.json
@@ -199,30 +199,6 @@
     ]
   },
   {
-    "from": "i18n",
-    "to": [
-      "dhruvjainpenny@gmail.com",
-      "obensource@benmichel.com",
-      "richard.littauer@gmail.com",
-      "zeke@sikelianos.com"
-    ]
-  },
-  {
-    "from": "node-slack-bot",
-    "to": [
-      "georgeadams1995@gmail.com"
-    ]
-  },
-  {
-    "from": "website-redesign",
-    "to": [
-      "adam@mobilize.app",
-      "dhruvjainpenny@gmail.com",
-      "hello@bnb.im",
-      "manil.chowdhury@gmail.com"
-    ]
-  },
-  {
     "from": "zoom-nodejs",
     "to": [
       "bencoe@google.com",


### PR DESCRIPTION
These email addresses have not been updated in a long time and consist mostly of people no longer involved and omit the people most currently active. Rather than update, let's remove.

The email addresses in question are:

* i18n
* node-slack-bot
* website-redesign

@nodejs/tsc @ovflowd 