### PR TITLE
Remove Claudio's email from Moderation team alias

### DIFF
--- a/iojs.org/aliases.json
+++ b/iojs.org/aliases.json
@@ -34,7 +34,6 @@
     "from": "report",
     "to": [
       "benjamingr@gmail.com",
-      "claudio.santoro.wunder@gmail.com",
       "duhamelantoine1995@gmail.com",
       "huyuumi.dev@gmail.com",
       "othiym23@gmail.com",


### PR DESCRIPTION
Claudio is taking some time off from the project, for that reason they asked me to remove their email address from the Moderation team alias.