### PR TITLE
Add ryanaslett to build email

### DIFF
--- a/iojs.org/aliases.json
+++ b/iojs.org/aliases.json
@@ -77,7 +77,8 @@
       "stefan.stojanovic@janeasystems.com",
       "sxa@redhat.com",
       "targos@protonmail.com",
-      "ulisesgascongonzalez@gmail.com"
+      "ulisesgascongonzalez@gmail.com",
+      "raslett@contractor.linuxfoundation.org"
     ]
   },
   {


### PR DESCRIPTION
Add ryanaslett to build@iojs.org mail alias.