### PR TITLE
add discord report aliases

### DIFF
--- a/iojs.org/aliases.json
+++ b/iojs.org/aliases.json
@@ -45,6 +45,13 @@
     ]
   },
   {
+    "from": "report-discord",
+    "to": [
+      "claudio.santoro.wunder@gmail.com",
+      "vcarl@reactiflux.com"
+    ]
+  },
+  {
     "from": "admin",
     "to": [
       "midawson@redhat.com",

--- a/iojs.org/aliases.json
+++ b/iojs.org/aliases.json
@@ -48,7 +48,9 @@
     "from": "report-discord",
     "to": [
       "claudio.santoro.wunder@gmail.com",
-      "vcarl@reactiflux.com"
+      "vcarl@reactiflux.com",
+      "nicholainissen@gmail.com",
+      "subone@subone.org"
     ]
   },
   {


### PR DESCRIPTION
As agreed on in internal discussions with the moderation team (cc @nodejs/moderation), the Discord server will have its own moderation to avoid overburdening our current moderation team.

Hence creating a dedicated alias for it. Since I'm going to be the main point of contact with the Discord team, I'll add myself so we can also keep an eye on the incoming emails they receive.

Anyone else from the Node.js moderation team is welcome to add themselves here.

cc @nodejs/tsc 